### PR TITLE
Add / as allowed route for k8s role

### DIFF
--- a/kubernetes/clusterrole.yaml
+++ b/kubernetes/clusterrole.yaml
@@ -27,3 +27,5 @@ rules:
       - deployments
       - daemonsets
     verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ['/']
+    verbs: ["get"]


### PR DESCRIPTION
Save & test endpoint performs request to / endpoint. W/o that rule
it would be ended with 403 and DS validation would be failed