### PR TITLE
fix datasource for containers statuses in pod dashboard

### DIFF
--- a/dist/dashboards/pod-resources.json
+++ b/dist/dashboards/pod-resources.json
@@ -497,7 +497,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$PromDs",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/src/dashboards/pod-resources.json
+++ b/src/dashboards/pod-resources.json
@@ -497,7 +497,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$PromDs",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {


### PR DESCRIPTION
Small bug in the Pod's Dashboard in the graph Containers' statuses. There is wrongly defined datasource for this graph which doesn't work because of it (`"datasource": null` instead of `"datasource": "$PromDs"`).

There is no issue for this, I only mentioned it in #24 (because I found it during checking fixes for this issue).