### PR TITLE
Fix prometheus query for node mem & cpu requests

### DIFF
--- a/dist/components/k8s-page.js
+++ b/dist/components/k8s-page.js
@@ -159,7 +159,7 @@ System.register(["app/core/app_events", "../common/types/pod", "../common/proxie
                 };
                 K8sPage.prototype.__getCpuMetricsRequested = function () {
                     var promQuery = {
-                        expr: 'sum(kube_pod_container_resource_requests_cpu_cores) by (node)',
+                        expr: 'sum(sum(kube_pod_container_resource_requests_cpu_cores) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
                         legend: 'node'
                     };
                     return this.prometheusDS.query(promQuery)
@@ -167,7 +167,7 @@ System.register(["app/core/app_events", "../common/types/pod", "../common/proxie
                 };
                 K8sPage.prototype.__getMemoryMetricsRequested = function () {
                     var promQuery = {
-                        expr: 'sum(kube_pod_container_resource_requests_memory_bytes) by (node)',
+                        expr: 'sum(sum(kube_pod_container_resource_requests_memory_bytes) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
                         legend: "node"
                     };
                     return this.prometheusDS.query(promQuery)
@@ -899,4 +899,3 @@ System.register(["app/core/app_events", "../common/types/pod", "../common/proxie
         }
     }
 });
-//# sourceMappingURL=k8s-page.js.map

--- a/dist/components/k8s-page.ts
+++ b/dist/components/k8s-page.ts
@@ -163,7 +163,7 @@ export  class K8sPage {
 
     __getCpuMetricsRequested(){
         const promQuery = {
-            expr: 'sum(kube_pod_container_resource_requests_cpu_cores) by (node)',
+            expr: 'sum(sum(kube_pod_container_resource_requests_cpu_cores) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
             legend: 'node'
         };
 
@@ -173,7 +173,7 @@ export  class K8sPage {
 
     __getMemoryMetricsRequested(){
         const promQuery = {
-            expr: 'sum(kube_pod_container_resource_requests_memory_bytes) by (node)',
+            expr: 'sum(sum(kube_pod_container_resource_requests_memory_bytes) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
             legend: "node"
         };
 

--- a/dist/module.js
+++ b/dist/module.js
@@ -20283,7 +20283,7 @@ function () {
 
   K8sPage.prototype.__getCpuMetricsRequested = function () {
     var promQuery = {
-      expr: 'sum(kube_pod_container_resource_requests_cpu_cores) by (node)',
+      expr: 'sum(sum(kube_pod_container_resource_requests_cpu_cores) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
       legend: 'node'
     };
     return this.prometheusDS.query(promQuery).then(function (res) {
@@ -20293,7 +20293,7 @@ function () {
 
   K8sPage.prototype.__getMemoryMetricsRequested = function () {
     var promQuery = {
-      expr: 'sum(kube_pod_container_resource_requests_memory_bytes) by (node)',
+      expr: 'sum(sum(kube_pod_container_resource_requests_memory_bytes) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
       legend: "node"
     };
     return this.prometheusDS.query(promQuery).then(function (res) {

--- a/src/components/k8s-page.ts
+++ b/src/components/k8s-page.ts
@@ -204,7 +204,7 @@ export  class K8sPage {
 
     __getCpuMetricsRequested(){
         const promQuery = {
-            expr: 'sum(kube_pod_container_resource_requests_cpu_cores) by (node)',
+            expr: 'sum(sum(kube_pod_container_resource_requests_cpu_cores) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
             legend: 'node'
         };
 
@@ -214,7 +214,7 @@ export  class K8sPage {
 
     __getMemoryMetricsRequested(){
         const promQuery = {
-            expr: 'sum(kube_pod_container_resource_requests_memory_bytes) by (node)',
+            expr: 'sum(sum(kube_pod_container_resource_requests_memory_bytes) by (namespace, pod, node) * on (pod) group_left()  (sum(kube_pod_status_phase{phase="Running"}) by (pod, namespace) == 1)) by (node)',
             legend: "node"
         };
 


### PR DESCRIPTION
Hi, I found bug on Nodes Overview page.

![image](https://user-images.githubusercontent.com/10445445/88684809-e970ab80-d0fd-11ea-8a9c-2fb56f1f2c3b.png)

**The reason** of this incorrect prometheus query:

`sum(kube_pod_container_resource_requests_cpu_cores) by (node)`

This query contains pods which not running now (for example completed jobs)

**Solution**: Exclude not running pods in query which calculate node mem/cpu requests