### PR TITLE
pod's dashboard - show container's (not pod's) memory and cpu requests on respective graphs

### DIFF
--- a/dist/dashboards/pod-resources.json
+++ b/dist/dashboards/pod-resources.json
@@ -203,7 +203,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"})",
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\", container=~\"$containers\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requested",
@@ -296,7 +296,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$pod\", container=~\"$containers\"})",
           "legendFormat": "Requested",
           "refId": "B"
         }

--- a/src/dashboards/pod-resources.json
+++ b/src/dashboards/pod-resources.json
@@ -203,7 +203,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"})",
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\", container=~\"$containers\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requested",
@@ -296,7 +296,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$pod\", container=~\"$containers\"})",
           "legendFormat": "Requested",
           "refId": "B"
         }


### PR DESCRIPTION
Pod's Dashboard on Memory usage and CPU usage graphs shows used resources for one container only (not for whole pod), but at the same time it shows requests for whole pod (sum of all pod's containers requests). It doesn't make sense. It's quite confusing, if pod has more than one container. It should show only container's request as well.